### PR TITLE
Hotfix pyupgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "isort >= 5.7.0",
         "libcst >= 0.3.16",
         "pybetter >= 0.3.6.1",
-        "pyupgrade >= 2.7.4",
+        "pyupgrade == 2.7.4",
         "teyit >= 0.3.2 ; python_version >= '3.9'",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
This pins pyupgrade to `2.7.4` to address #12 before a more comprehensive fix is deployed