### PR TITLE
Check before using _fix_py36_plus

### DIFF
--- a/src/shed/__init__.py
+++ b/src/shed/__init__.py
@@ -164,7 +164,8 @@ def shed(
             source_code, settings=pyupgrade._main.Settings(min_version=pyupgrade_min)
         )
     source_code = pyupgrade._main._fix_tokens(source_code, min_version=pyupgrade_min)
-    source_code = pyupgrade._main._fix_py36_plus(source_code, min_version=pyupgrade_min)
+    if hasattr(pyupgrade._main, "_fix_py36_plus"):
+        source_code = pyupgrade._main._fix_py36_plus(source_code, min_version=pyupgrade_min)
 
     if refactor:
         source_code = _run_codemods(source_code, min_version=min_version)


### PR DESCRIPTION
As of pyupgrade 2.32.0 the method `_fix_py36_plus` has been removed and does not support python 3.6 anymore. Thus check is added in for those using pyupgrade 2.32.0 or above before calling `_fix_py36_plus` which does not exist anymore.

closes #33 