### PR TITLE
Rewrite `Optional[Literal[...]]` to `Literal[..., None]`

### DIFF
--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -56,7 +56,6 @@ def _run_codemods(code: str, min_version: Tuple[int, int]) -> str:
 
     if imports_hypothesis(code):  # pragma: no cover
         mod = attempt_hypothesis_codemods(context, mod)
-    # print(mod)
     mod = ShedFixers(context).transform_module(mod)
     return mod.code
 

--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -125,7 +125,6 @@ class ShedFixers(VisitorBasedCodemodCommand):
         )
     )
     def convert_optional_literal_to_literal_none(self, _, updated_node):
-        """Inspired by Pybetter."""
         expr = updated_node.slice[0].slice.value
         args = list(expr.slice)
         args[-1] = args[-1].with_changes(comma=cst.Comma())

--- a/tests/recorded/optionals_literal.txt
+++ b/tests/recorded/optionals_literal.txt
@@ -1,0 +1,7 @@
+Optional[Literal[1, 2]]  # Literal[1, 2, None]
+var: Optional[Literal[1, 2]] = 1  # Literal[1, 2, None]
+
+================================================================================
+
+Literal[1, 2, None]  # Literal[1, 2, None]
+var: Literal[1, 2, None] = 1  # Literal[1, 2, None]


### PR DESCRIPTION
Address the second task in #22. Note a subtask should be created to rewrite the `|` operator.