### PR TITLE
Reorder Union/Literal subscripts to put None last

### DIFF
--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -276,15 +276,10 @@ class ShedFixers(VisitorBasedCodemodCommand):
         return updated_node
 
     @m.leave(
-        m.Annotation(annotation=m.Subscript(value=m.Name(value="Union")))
-        | m.Annotation(annotation=m.Subscript(value=m.Name(value="Literal")))
+        m.Subscript(value=m.Name(value="Union"))
+        | m.Subscript(value=m.Name(value="Literal"))
     )
     def reorder_union_literal_contents_none_last(self, _, updated_node):
-        try:
-            ann_slice = list(updated_node.annotation.slice)
-        except AttributeError:
-            return updated_node
+        ann_slice = list(updated_node.slice)
         ann_slice.sort(key=lambda elt: elt.slice.value.value == "None")
-        return updated_node.with_changes(
-            annotation=updated_node.annotation.with_changes(slice=ann_slice)
-        )
+        return updated_node.with_changes(slice=ann_slice)

--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -282,4 +282,7 @@ class ShedFixers(VisitorBasedCodemodCommand):
     def reorder_union_literal_contents_none_last(self, _, updated_node):
         subscript_slice = list(updated_node.slice)
         subscript_slice.sort(key=lambda elt: elt.slice.value.value == "None")
+        subscript_slice[-1] = subscript_slice[-1].with_changes(
+            comma=cst.MaybeSentinel.DEFAULT
+        )
         return updated_node.with_changes(slice=subscript_slice)

--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -280,6 +280,6 @@ class ShedFixers(VisitorBasedCodemodCommand):
         | m.Subscript(value=m.Name(value="Literal"))
     )
     def reorder_union_literal_contents_none_last(self, _, updated_node):
-        ann_slice = list(updated_node.slice)
-        ann_slice.sort(key=lambda elt: elt.slice.value.value == "None")
-        return updated_node.with_changes(slice=ann_slice)
+        subscript_slice = list(updated_node.slice)
+        subscript_slice.sort(key=lambda elt: elt.slice.value.value == "None")
+        return updated_node.with_changes(slice=subscript_slice)

--- a/tests/recorded/reorder_none.txt
+++ b/tests/recorded/reorder_none.txt
@@ -9,31 +9,13 @@ Literal[None, 1]
 
 ================================================================================
 
-def f(
-    x: Union[
-        int,
-        str,
-        None,
-    ] = 3
-):
+def f(x: Union[int, str, None] = 3):
     pass
 
 
-def g(
-    x: Literal[
-        1,
-        None,
-    ] = None
-):
+def g(x: Literal[1, None] = None):
     pass
 
 
-Union[
-    int,
-    str,
-    None,
-]
-Literal[
-    1,
-    None,
-]
+Union[int, str, None]
+Literal[1, None]

--- a/tests/recorded/reorder_none.txt
+++ b/tests/recorded/reorder_none.txt
@@ -1,0 +1,49 @@
+def f1(x: Union[int, None, str] = 3):
+    pass
+
+
+def g1(x: Union):
+    pass
+
+
+def f2(x: Literal[None, 1] = None):
+    pass
+
+
+def g2(x: Literal):
+    pass
+
+Union[int, None, str]
+Literal[None, 1]
+
+================================================================================
+
+def f1(
+    x: Union[
+        int,
+        str,
+        None,
+    ] = 3
+):
+    pass
+
+
+def g1(x: Union):
+    pass
+
+
+def f2(
+    x: Literal[
+        1,
+        None,
+    ] = None
+):
+    pass
+
+
+def g2(x: Literal):
+    pass
+
+
+Union[int, None, str]
+Literal[None, 1]

--- a/tests/recorded/reorder_none.txt
+++ b/tests/recorded/reorder_none.txt
@@ -1,16 +1,7 @@
-def f1(x: Union[int, None, str] = 3):
+def f(x: Union[int, None, str] = 3):
     pass
 
-
-def g1(x: Union):
-    pass
-
-
-def f2(x: Literal[None, 1] = None):
-    pass
-
-
-def g2(x: Literal):
+def g(x: Literal[None, 1] = None):
     pass
 
 Union[int, None, str]
@@ -18,7 +9,7 @@ Literal[None, 1]
 
 ================================================================================
 
-def f1(
+def f(
     x: Union[
         int,
         str,
@@ -28,11 +19,7 @@ def f1(
     pass
 
 
-def g1(x: Union):
-    pass
-
-
-def f2(
+def g(
     x: Literal[
         1,
         None,
@@ -41,9 +28,12 @@ def f2(
     pass
 
 
-def g2(x: Literal):
-    pass
-
-
-Union[int, None, str]
-Literal[None, 1]
+Union[
+    int,
+    str,
+    None,
+]
+Literal[
+    1,
+    None,
+]


### PR DESCRIPTION
Addresses the third task (Reorder `Union` and `Literal` contents so that `None` is last) in #22