### PR TITLE
add codemod for splitting up 'assert a and b'

### DIFF
--- a/tests/recorded/split_assert.txt
+++ b/tests/recorded/split_assert.txt
@@ -1,0 +1,62 @@
+assert a and b # one
+
+assert a and b and c # two
+
+assert (a and b) # three
+
+assert a(1, 2) and b(3, 7) # four
+
+def f():
+    assert a and b
+
+assert (a and b) and (c and d)
+
+assert a or b and c
+assert a and b or c
+
+assert a and (b or c)
+
+assert (a or b) and c
+
+assert a or b
+
+assert a
+
+================================================================================
+
+assert a
+assert b  # one
+
+assert a
+assert b
+assert c  # two
+
+assert a
+assert b  # three
+
+assert a(1, 2)
+assert b(3, 7)  # four
+
+
+def f():
+    assert a
+    assert b
+
+
+assert a
+assert b
+assert c
+assert d
+
+assert a or b and c
+assert a and b or c
+
+assert a
+assert b or c
+
+assert a or b
+assert c
+
+assert a or b
+
+assert a


### PR DESCRIPTION
Fix first task in #22 

First PR to this repo, so I assume there's some doc I should update. And very possible my implementation is bad in one way or another.

I wanted to leave the comment on the first assert, or put it on a separate line before the first assert (lmk which one you prefer). Will figure out how to do that unless you're fine with it staying on the line of the last assert.