### PR TITLE
implement refactor of pie787, no-len-condition

### DIFF
--- a/tests/recorded/pie787_no_len.txt
+++ b/tests/recorded/pie787_no_len.txt
@@ -1,0 +1,145 @@
+if len(foo):
+    ...
+
+if True and len(foo):
+    ...
+
+if len(foo) and True:
+    ...
+
+if len(foo) and len(foo):
+    ...
+
+while len(foo):
+    ...
+
+print(0 if len(foo) else 1)
+
+[0 for i in range(10) if not len(foo)]
+
+if len(bar.foo):
+    ...
+
+if len(bar.zee.foo):
+    ...
+
+if len(foo()):
+    ...
+
+if len(bar.foo()):
+    ...
+
+if len({1: 2}):
+    ...
+
+if len([1, 2]):
+    ...
+
+if len({1: 2 for _ in range(10)}):
+    ...
+
+if len([i*a for i in range(10)]):
+    ...
+
+print(5+(1 if len(foo) else 0))
+
+# these should not be modified
+
+k = len
+k = len()
+k = len(foo)
+
+len(foo)
+if len(foo, bar):
+    ...
+if len(bar=5):
+    ...
+
+if 3+len(foo):
+    ...
+
+if (3+len(foo) == 5):
+    ...
+
+if len(foo) == 2:
+    ...
+
+if zoobies(5+len(foo)):
+    ...
+
+if len(foo(5+len(foo))):
+    ...
+
+================================================================================
+
+if foo:
+    ...
+
+if True and foo:
+    ...
+
+if foo and True:
+    ...
+
+if foo and foo:
+    ...
+
+while foo:
+    ...
+
+print(0 if foo else 1)
+
+[0 for i in range(10) if not foo]
+
+if bar.foo:
+    ...
+
+if bar.zee.foo:
+    ...
+
+if foo():
+    ...
+
+if bar.foo():
+    ...
+
+if {1: 2}:
+    ...
+
+if [1, 2]:
+    ...
+
+if {1: 2 for _ in range(10)}:
+    ...
+
+if [i * a for i in range(10)]:
+    ...
+
+print(5 + (1 if foo else 0))
+
+# these should not be modified
+
+k = len
+k = len()
+k = len(foo)
+
+len(foo)
+if len(foo, bar):
+    ...
+if len(bar=5):
+    ...
+
+if 3 + len(foo):
+    ...
+
+if 3 + len(foo) == 5:
+    ...
+
+if len(foo) == 2:
+    ...
+
+if zoobies(5 + len(foo)):
+    ...
+
+if foo(5 + len(foo)):
+    ...


### PR DESCRIPTION
Kind of a pain, it would be *really* handy if I could trigger `m.leave` on the call node and use `m.call_if_inside` - wouldn't have to use the sketchy `attr`-stuff then. But `m.call_if_inside` triggers if any parent matches, such that
```python
if foo(5+len(foo))
```
can easily trigger. If you also add `m.call_if_not_inside` on various stuff, then it will fail on
```python
5 + (0 if len(foo) else 1)
```

I don't see any other way of solving it, so this is it.

I don't think it's too easy to combine the multiple `m.leave`s, but with a helper function it's decent (putting it into a variable didn't seem to work?). Kinda ugly to have the helper function randomly placed outside the class, so could move it.

I might have missed a case or two, and there's a small risk I break something, but I *think* it's fine.