### PR TITLE
Do not convert `== True/False` to `is`.

### DIFF
--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -134,12 +134,7 @@ class ShedFixers(VisitorBasedCodemodCommand):
             cst.Call(cst.Name("AssertionError"), args=[cst.Arg(updated_node.msg)])
         )
 
-    @m.leave(
-        m.ComparisonTarget(
-            comparator=oneof_names("None", "False", "True"), operator=m.Equal()
-        )
-    )
-    @m.call_if_not_inside(m.Index())  # Pandas idiom, e.g. df[df.flag == True]
+    @m.leave(m.ComparisonTarget(comparator=m.Name("None"), operator=m.Equal()))
     def convert_none_cmp(self, _, updated_node):
         """Inspired by Pybetter."""
         return updated_node.with_changes(operator=cst.Is())

--- a/tests/recorded/pybetter.txt
+++ b/tests/recorded/pybetter.txt
@@ -17,8 +17,8 @@ with a:
 
 x not in y
 z is None
-a is True
-a is False
+a == True
+a == False
 df[df.flag == True]  # doesn't break Pandas code
 
 with a:


### PR DESCRIPTION
Fixes #74.

This updates `shed --refactor` so that equality comparisons with True or False are no longer converted to `is` under an circumstances, as it is a fundamentally semantics changing refactor.

In particular the strongest prompting example is that `1.0 == True` is true, but `1.0 is True` is false.

This change leaves the logic for converting `x == None` to `x is None` in place, as although this can in principle change semantics, it should not for an well-behaved equalit implementation, and I'm not aware of any examples in the wild of equality being badly behaved in this particular way.