### PR TITLE
Don't merge nested calls to sorted with a key.

### DIFF
--- a/src/shed/_codemods.py
+++ b/src/shed/_codemods.py
@@ -295,6 +295,21 @@ class ShedFixers(VisitorBasedCodemodCommand):
 
         Unnecessary <list/reversed/sorted/tuple> call within <list/set/sorted/tuple>()..
         """
+        # If either of two nested sorted calls have a key, it's incorrect to try
+        # to merge them. Theoretically the keys could be combined into a tuple,
+        # but this is hard to make work in generality, and it's better to just
+        # leave this alone and let a human deal with it if they care.
+        if (
+            updated_node.func.value == "sorted"
+            and updated_node.args[0].value.func.value == "sorted"
+            and any(
+                arg.keyword and arg.keyword.value == "key"
+                for args in (updated_node.args, updated_node.args[0].value.args)
+                for arg in args
+            )
+        ):
+            return updated_node
+
         return updated_node.with_changes(
             args=[cst.Arg(updated_node.args[0].value.args[0].value)]
             + list(updated_node.args[1:]),

--- a/tests/recorded/sorted.txt
+++ b/tests/recorded/sorted.txt
@@ -1,0 +1,25 @@
+sorted(sorted(xs))
+sorted(sorted(xs), reverse=True)
+sorted(sorted(xs, reverse=True))
+sorted(sorted(xs, reverse=True), reverse=True)
+
+sorted(sorted(xs, key=lambda x: 0))
+sorted(sorted(xs), key=lambda x: 0)
+sorted(sorted(xs, key=lambda x: 1), key=lambda x: 0)
+
+reversed(sorted(xs))
+reversed(sorted(xs, key=lambda x: 0))
+
+================================================================================
+
+sorted(xs)
+sorted(xs, reverse=True)
+sorted(xs)
+sorted(xs, reverse=True)
+
+sorted(sorted(xs, key=lambda x: 0))
+sorted(sorted(xs), key=lambda x: 0)
+sorted(sorted(xs, key=lambda x: 1), key=lambda x: 0)
+
+sorted(xs, reverse=True)
+sorted(xs, key=lambda x: 0, reverse=True)

--- a/tests/test_shed.py
+++ b/tests/test_shed.py
@@ -21,7 +21,17 @@ import unittest
 
 unittest.assertIs(a > b, True)
 """
-NOT_YET_FIXED = ("C402", "C406", "C408", "C409", "C410")
+NOT_YET_FIXED = (
+    "C402",
+    "C406",
+    "C408",
+    "C409",
+    "C410",
+    # This error will fire in cases where it would be inappropriate
+    # to fix automatically (because e.g. sorted has a call to key),
+    # so we can't always reliably fix it.
+    "C414",
+)
 
 
 def check(


### PR DESCRIPTION
Fixes #69

Possibly there's a more idiomatic way to do this with libcst matchers - I'm new to the library so wasn't sure - but if so it wasn't obvious to me, and this seemed a straightforward enough way to do it. Let me know if there's an approach you'd prefer.