### PR TITLE
Run isort before and after autoflake.

### DIFF
--- a/src/shed/__init__.py
+++ b/src/shed/__init__.py
@@ -162,22 +162,34 @@ def shed(
     if refactor and not is_pyi:
         source_code = _run_codemods(source_code, min_version=min_version)
 
-    try:
-        source_code = isort.code(
-            source_code,
-            known_first_party=first_party_imports,
-            known_local_folder={"tests"},
-            profile="black",
-            combine_as_imports=True,
-        )
-    except FileSkipComment:
-        pass
+    def run_isort():
+        try:
+            return isort.code(
+                source_code,
+                known_first_party=first_party_imports,
+                known_local_folder={"tests"},
+                profile="black",
+                combine_as_imports=True,
+            )
+        except FileSkipComment:
+            return source_code
+
+    # Autoflake cannot always correctly resolve imports it can remove until
+    # they have been properly formatted, so we have to run isort first so that
+    # it gets well formatted imports.
+    pre_autoflake = source_code = run_isort()
 
     source_code = autoflake.fix_code(
         source_code,
         expand_star_imports=True,
         remove_all_unused_imports=_remove_unused_imports,
     )
+
+    # Until https://github.com/PyCQA/autoflake/issues/229 is fixed, autoflake
+    # may reorder imports in a way that is incompatible with isort's ordering,
+    # so we may need to re-sort its output.
+    if source_code != pre_autoflake:
+        source_code = run_isort()
 
     if source_code != blackened:
         source_code = black.format_str(source_code, mode=black_mode)

--- a/src/shed/__init__.py
+++ b/src/shed/__init__.py
@@ -162,7 +162,7 @@ def shed(
     if refactor and not is_pyi:
         source_code = _run_codemods(source_code, min_version=min_version)
 
-    def run_isort():
+    def run_isort() -> str:
         try:
             return isort.code(
                 source_code,

--- a/tests/recorded/issue75.txt
+++ b/tests/recorded/issue75.txt
@@ -1,0 +1,32 @@
+from os import (
+    wait,
+    wait3,
+    wait4,
+    waitid,
+    waitid_result,
+    waitpid,
+    waitstatus_to_exitcode,
+    walk,
+    write,
+    writev,
+)
+
+print(
+    waitpid,
+    waitstatus_to_exitcode,
+    walk,
+    write,
+    writev,
+)
+
+================================================================================
+
+from os import waitpid, waitstatus_to_exitcode, walk, write, writev
+
+print(
+    waitpid,
+    waitstatus_to_exitcode,
+    walk,
+    write,
+    writev,
+)

--- a/tests/recorded/issue78.txt
+++ b/tests/recorded/issue78.txt
@@ -1,0 +1,9 @@
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
+
+x = (TYPE_CHECKING, NamedTuple, TypeVar)
+
+================================================================================
+
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
+
+x = (TYPE_CHECKING, NamedTuple, TypeVar)


### PR DESCRIPTION
Fixes #78, #75

The proposed solution in #78 was to swap the order of isort and autoflake, but this doesn't currently work because you run into https://github.com/PyCQA/autoflake/issues/106 (which I think is the reason why it's currently the way around that it is). Running isort, then autoflake, then isort again, seems to be sufficient to solve this problem.

I looked into a more sophisticated solution which treats this as a running multiple passes to their collective fixed point, and it worked fine but didn't seem to have any real benefit to it and was a bit messier than what was currently here, so this just takes the simplest approach that will work.