### PR TITLE
tweak tox so python version can be specified in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,20 @@
 [tox]
 envlist = check, test
 
+# Primary test environment that will be called unless name matches one of the other
+# described environments. This way it can be called with `tox -e test` (or any name other
+# than check/deps) - but importantly can be called while specifying python version.
+# e.g. `tox -e py310` will run tests in a python3.10 environment.
+[testenv]
+description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`
+deps =
+    # --no-deps
+    --requirement deps/test.txt
+passenv =
+    SHED_SLOW_TESTS
+commands =
+    pytest {posargs:-n auto}
+
 [testenv:check]
 description = Runs all formatting tools then static analysis (quick)
 ignore_errors = true
@@ -13,16 +27,6 @@ commands =
     shed
     flake8
     mypy --config-file=tox.ini src/
-
-[testenv:test]
-description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`
-deps =
-    # --no-deps
-    --requirement deps/test.txt
-passenv =
-    SHED_SLOW_TESTS
-commands =
-    pytest {posargs:-n auto}
 
 [testenv:deps]
 description = Updates test corpora and the pinned dependencies in `deps/*.txt`


### PR DESCRIPTION
Arch Linux has updated default python version to 3.11, and shed's tests don't run on 3.11, so I tweaked the tox config so it's possible to specify python version. Uses same setup as I wrote for `flake8-trio` https://github.com/Zac-HD/flake8-trio/blob/main/tox.ini