### PR TITLE
Adding error message if filename has glob pattern

### DIFF
--- a/src/shed/_cli.py
+++ b/src/shed/_cli.py
@@ -66,7 +66,10 @@ def _rewrite_on_disk(
             on_disk = wrapper.read()
     except (OSError, UnicodeError) as err:
         # Permissions or encoding issue, or file deleted since last commit.
-        return f"skipping {fname!r} due to {err}"
+        err_msg = f"skipping {fname!r} due to {err}"
+        if "*" in fname:
+            err_msg += ", maybe due to unexpanded glob pattern?"
+        return err_msg
     if fname.endswith((".md", ".rst")):
         writer: Callable[..., str] = docshed
     elif fname.endswith(".pyi"):

--- a/tests/test_shed.py
+++ b/tests/test_shed.py
@@ -166,12 +166,20 @@ def test_rewrite_on_disk(fname, contents, changed):
     assert changed == (contents != result)
 
 
-def test_rewrite_returns_error_message_for_nonexistent_file():
+@pytest.mark.parametrize(
+    "fname, err_msg",
+    [
+        ("nonexistent", "No such file or directory"),
+        ("*.nonexistent", "maybe due to unexpanded glob pattern?"),
+    ],
+)
+def test_rewrite_returns_error_message_for_nonexistent_file(fname, err_msg):
     kwargs = {"refactor": True, "first_party_imports": frozenset()}
     with tempfile.TemporaryDirectory() as dirname:
-        f = Path(dirname) / "nonexistent"
+        f = Path(dirname) / fname
         result = _rewrite_on_disk(str(f), **kwargs)
-        assert isinstance(result, str)
+        # assert isinstance(result, str)
+        assert err_msg in result
         f.write_text("# comment\n")
         assert _rewrite_on_disk(str(f), **kwargs) is False
 

--- a/tests/test_shed.py
+++ b/tests/test_shed.py
@@ -178,7 +178,6 @@ def test_rewrite_returns_error_message_for_nonexistent_file(fname, err_msg):
     with tempfile.TemporaryDirectory() as dirname:
         f = Path(dirname) / fname
         result = _rewrite_on_disk(str(f), **kwargs)
-        # assert isinstance(result, str)
         assert err_msg in result
         f.write_text("# comment\n")
         assert _rewrite_on_disk(str(f), **kwargs) is False


### PR DESCRIPTION
Adding error message if a filename has glob pattern like "*.py"

close #65 