### PR TITLE
Use ruff to replace autoflake, pyupgrade, isort and black

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         "isort >= 5.10.1",
         "libcst >= 1.1.0",
         "pyupgrade >= 3.15.0",
+        "ruff >= 0.1.2",  # egregious case of 0ver.org
     ],
     python_requires=">=3.8",
     classifiers=[


### PR DESCRIPTION
This PR is a work in progress, with the intention of getting feedback before getting into the weeds on indicidual failing tests.

Tasks remaining:

- [ ] Get existing tests to pass (or update those that need updating)
- [ ] Remove dependency on black for determining python version
- [ ] [Optional] Use existing ruff.toml / prproject.toml for ruff configuration if present