### PR TITLE
Ignore F401 in __init__.py

### DIFF
--- a/src/shed/_cli.py
+++ b/src/shed/_cli.py
@@ -84,6 +84,8 @@ def _rewrite_on_disk(
         writer: Callable[..., str] = docshed
     elif fname.endswith(".pyi"):
         writer = functools.partial(shed, is_pyi=True)
+    elif Path(fname).name == "__init__.py":
+        writer = functools.partial(shed, _remove_unused_imports=False)
     else:
         writer = shed
 


### PR DESCRIPTION
Ruff by default ignores unused imports in `__init__.py`, since they are often (usually?) intended to be public and removing them breaks code elsewhere. This PR makes shed do the same.

https://docs.astral.sh/ruff/settings/#lint_ignore-init-module-imports

