### PR TITLE
Improve `shed` speed in the presence of large dot directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 *`shed` uses [calendar versioning](https://calver.org/), with a year.month.patch scheme.*
 
-#### 2025.6.4 - 2025-06-04-
+#### 2025.6.4 - 2025-06-04
 - Improve performance in large repositories, by skipping directories that start with `.` during an internal check.
 
 #### 2024.10.1 - 2024-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *`shed` uses [calendar versioning](https://calver.org/), with a year.month.patch scheme.*
 
+#### 2025.6.4 - 2025-06-04-
+- Improve performance in large repositories, by skipping directories that start with `.` during an internal check.
+
 #### 2024.10.1 - 2024-04-27
 - Disable `PIE790` fix due to [ruff issue #10538](https://github.com/astral-sh/ruff/issues/10538)
 - [Python 3.8 has reached end-of-life](https://devguide.python.org/versions/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 *`shed` uses [calendar versioning](https://calver.org/), with a year.month.patch scheme.*
 
-#### 2025.6.4 - 2025-06-04
+#### 2025.6.1 - 2025-06-05
 - Improve performance in large repositories, by skipping directories that start with `.` during an internal check.
 
 #### 2024.10.1 - 2024-04-27

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ adding the following to your `.pre-commit-config.yaml`:
 minimum_pre_commit_version: '2.9.0'
 repos:
 - repo: https://github.com/Zac-HD/shed
-  rev: 2025.6.4
+  rev: 2025.6.1
   hooks:
     - id: shed
       # args: [--refactor, --py311-plus]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ adding the following to your `.pre-commit-config.yaml`:
 minimum_pre_commit_version: '2.9.0'
 repos:
 - repo: https://github.com/Zac-HD/shed
-  rev: 2024.10.1
+  rev: 2025.6.4
   hooks:
     - id: shed
       # args: [--refactor, --py311-plus]

--- a/src/shed/__init__.py
+++ b/src/shed/__init__.py
@@ -19,7 +19,7 @@ import black
 from black.mode import TargetVersion
 from black.parsing import lib2to3_parse
 
-__version__ = "2025.6.4"
+__version__ = "2025.6.1"
 __all__ = ["shed", "docshed"]
 
 # Conditionally imported in refactor mode to reduce startup latency in the common case

--- a/src/shed/__init__.py
+++ b/src/shed/__init__.py
@@ -19,7 +19,7 @@ import black
 from black.mode import TargetVersion
 from black.parsing import lib2to3_parse
 
-__version__ = "2024.10.1"
+__version__ = "2025.6.4"
 __all__ = ["shed", "docshed"]
 
 # Conditionally imported in refactor mode to reduce startup latency in the common case

--- a/src/shed/_cli.py
+++ b/src/shed/_cli.py
@@ -61,7 +61,7 @@ def _guess_first_party_modules(cwd: Optional[str] = None) -> FrozenSet[str]:
                     provides |= _walk_path(p)
                 else:
                     provides |= _walk_path(p)
-        except Exception:
+        except Exception:  # pragma: no cover
             pass
 
         return provides

--- a/src/shed/_cli.py
+++ b/src/shed/_cli.py
@@ -47,7 +47,26 @@ def _guess_first_party_modules(cwd: Optional[str] = None) -> FrozenSet[str]:
         base = _get_git_repo_root(cwd)
     except (subprocess.SubprocessError, FileNotFoundError):
         return frozenset()
-    provides = {init.parent.name for init in Path(base).glob("**/src/*/__init__.py")}
+
+    def _walk_path(path: Path) -> set[str]:
+        provides = set()
+        try:
+            for p in path.iterdir():
+                if p.name.startswith(".") or not p.is_dir():
+                    continue
+                if p.name == "src":
+                    provides |= {init.parent.name for init in p.glob("*/__init__.py")}
+                    # in case of nested src/ directories, like
+                    #   src/tools/src/helper/__init__.py
+                    provides |= _walk_path(p)
+                else:
+                    provides |= _walk_path(p)
+        except Exception:
+            pass
+
+        return provides
+
+    provides = _walk_path(Path(base))
     return frozenset(
         p
         for p in {Path(base).name} | provides

--- a/src/shed/_is_python_file.py
+++ b/src/shed/_is_python_file.py
@@ -72,7 +72,7 @@ def _detect_encoding(
 
 
 def _inner_detect_encoding(
-    readline: Callable[[], bytes | bytearray]
+    readline: Callable[[], bytes | bytearray],
 ) -> str:  # pragma: no cover
     """Return file encoding."""
     try:


### PR DESCRIPTION
This substantially speeds up a local run of `shed` on my hypofuzz install (10 seconds -> 0.5s), probably because I have an enormous `.hypothesis` directory (200mb, thousands of dirs). But I also expect this to be helpful for e.g. large .git dirs, large .tox dirs, etc.

I'm reasonably but not entirely confident this is equivalent